### PR TITLE
Fixing depency injection error: Too many positional arguments: 0 allo…

### DIFF
--- a/lib/ui/viewmodels/home/home_viewmodel.dart
+++ b/lib/ui/viewmodels/home/home_viewmodel.dart
@@ -10,10 +10,10 @@ class HomeViewModel extends RootViewModel<HomeViewState> {
   final ExampleRepository exampleRepository;
   final MainNavigator navigator;
 
-  HomeViewModel({
-    required this.navigator,
-    required this.exampleRepository,
-  }) : super(const Loading());
+  HomeViewModel(
+    this.navigator,
+    this.exampleRepository,
+  ) : super(const Loading());
 
   @override
   void onAttach() async {

--- a/lib/ui/viewmodels/splash/splash_viewmodel.dart
+++ b/lib/ui/viewmodels/splash/splash_viewmodel.dart
@@ -12,10 +12,10 @@ class SplashViewModel extends RootViewModel<SplashViewState> {
   final SystemRepository systemRepository;
   final MainNavigator navigator;
 
-  SplashViewModel({
-    required this.navigator,
-    required this.systemRepository,
-  }) : super(const Loading());
+  SplashViewModel(
+    this.navigator,
+    this.systemRepository,
+  ) : super(const Loading());
 
   @override
   void onAttach() async {


### PR DESCRIPTION
This PR fixes the following depency injection error in HomeViewModel and SplashViewModel:
Error: Too many positional arguments: 0 allowed, but 2 found.

## Connection with issue(s)

Resolve issue #???

No issue

Connected to #???

Not connected

## Testing and Review Notes

After fixing I had no problem running this app

## Screenshots or Videos

![image](https://github.com/worldline-spain/flutter_architecture_template/assets/3913433/8769e58e-9517-4c7b-a1e3-594eb1ef2fc4)

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
