### PR TITLE
Parse original error code from Dio response instead of always 500 error

### DIFF
--- a/lib/data/transformers/error_transformer.dart
+++ b/lib/data/transformers/error_transformer.dart
@@ -43,6 +43,7 @@ MainError errorsHandler(DioException error) {
 /// Convert api messages
 (String, String) _apiRest(Response? response) {
   String apiErrorMessage = '';
+  int errorCode = response?.statusCode ?? 500;
   if (response != null) {
     final data = response.data;
     if (data is List) {
@@ -54,5 +55,5 @@ MainError errorsHandler(DioException error) {
   } else {
     apiErrorMessage = 'Empty or invalid response';
   }
-  return ('500', apiErrorMessage);
+  return (errorCode, apiErrorMessage);
 }

--- a/lib/data/transformers/error_transformer.dart
+++ b/lib/data/transformers/error_transformer.dart
@@ -3,12 +3,8 @@ import 'package:worldline_flutter/domain/models/errors.dart';
 
 /// Convert dio errors to domain errors
 MainError errorsHandler(DioException error) {
-  final (String httpCode, String apiErrorMessage) = _apiRest(error.response);
+  final (int errorCode, String apiErrorMessage) = _apiRest(error.response);
 
-  final int errorCode = (httpCode.isEmpty
-          ? error.response?.statusCode
-          : int.tryParse(httpCode)) ??
-      0;
   switch (errorCode) {
     case 400:
       return BadRequestError(
@@ -41,9 +37,9 @@ MainError errorsHandler(DioException error) {
 }
 
 /// Convert api messages
-(String, String) _apiRest(Response? response) {
+(int, String) _apiRest(Response? response) {
   String apiErrorMessage = '';
-  int errorCode = response?.statusCode ?? 500;
+  final int errorCode = response?.statusCode ?? 500;
   if (response != null) {
     final data = response.data;
     if (data is List) {


### PR DESCRIPTION
It's just a small change, to take into account HTTP response code instead getting 500 errors. I considered it was a mistake to return always 500 error code
